### PR TITLE
dont assume all models have a name prop in diff resolvers

### DIFF
--- a/versionator/changelog/changelog_graphql/types/diff.py
+++ b/versionator/changelog/changelog_graphql/types/diff.py
@@ -141,7 +141,7 @@ class M2MDiffObject(AsyncDiffObject):
             ]
         )
 
-        get_name = lambda inst: inst.name
+        get_name = lambda inst: inst.__str__()
         before_list = sorted([*prev_instances], key=get_name)
         after_list = sorted([*current_instances], key=get_name)
 
@@ -237,7 +237,7 @@ def m2m_display_value(version, field_obj, dataloader_cache):
     related_dataloader = related_dataloader_cls(dataloader_cache)
     related_instances = yield related_dataloader.load_many(id_list)
 
-    sorted_names = sorted([inst.name for inst in related_instances])
+    sorted_names = sorted([inst.__str__() for inst in related_instances])
     return "".join([f"<p>{name}</p>" for name in sorted_names])
 
 


### PR DESCRIPTION
This was causing issues in models that don't have a name property. This shouldn't cause any major issues for existing consumers, they may notice they have different representation shown in m2m diffs, or that things are sorted slightly differently. 

Longer term, we should start using the live-name-loaders for max configuration and N+1 mitigation rather than __str__ or name